### PR TITLE
fix: Change timeout invocation to support breaking change

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -53,9 +53,9 @@ wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
     if [[ $WAITFORIT_QUIET -eq 1 ]]; then
-        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+        timeout $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
     else
-        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+        timeout $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
     fi
     WAITFORIT_PID=$!
     trap "kill -INT -$WAITFORIT_PID" INT
@@ -146,11 +146,9 @@ WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
 WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
 if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
         WAITFORIT_ISBUSY=1
-        WAITFORIT_BUSYTIMEFLAG="-t"
 
 else
         WAITFORIT_ISBUSY=0
-        WAITFORIT_BUSYTIMEFLAG=""
 fi
 
 if [[ $WAITFORIT_CHILD -gt 0 ]]; then


### PR DESCRIPTION
In busybox commit [c9720a761][], a breaking change was introduced that
removes the `-t` flag to `timeout` in favor of just taking the time as
the second arg, bringing it in line with coreutils' `timeout`. This
commit was included in tag [1.31.1][], released on 25 Oct, 2019, at
which point my integration tests that spin up a server using wait-for-it
started to fail.

[c9720a761]: https://github.com/mirror/busybox/commit/c9720a761e88e83265b4d75808533cdfbc66075b
[1.31.1]: https://github.com/mirror/busybox/releases/tag/1_31_1